### PR TITLE
fix bootstrapping of etcd config

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
   command: "{{etcd_bin_dir}}/etcdctl --ca-file={{etcd_conf_dir}}/ca-etcd.pem get {{flannel_etcd_prefix}}/config"
   register: flannel_configured
   run_once: true
+  ignore_errors: true
   delegate_to: "{{groups.k8s_etcd|first}}"
   tags:
     - k8s-flannel

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: Setup flannel network configuration in etcd if needed
   command: "etcdctl --ca-file={{etcd_conf_dir}}/ca-etcd.pem set {{flannel_etcd_prefix}}/config \'{\"Network\":\"{{flannel_ip_range}}\"}\'" 
-  when: flannel_configured.stderr.find('Key not found') == 1
+  when: flannel_configured.stderr.find('Key not found') != -1
   run_once: true
   delegate_to: "{{groups.k8s_etcd|first}}"
   tags:


### PR DESCRIPTION
I needed to make a few minor changes to initial priming of the etcd config, namely:

- `ignore_errors: true` on check, otherwise the whole playbook fails
- match `'Key not found'` anywhere within`flannel_configured.stderr`  since etcd prefixes this with `[Error] ..`