### PR TITLE
Fixed a spacing issue: `{ {xxx` => `{{ xxx`

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
 - name: Copy etcd certificates
   copy:
     src: "{{ k8s_ca_conf_directory }}/{{ item }}"
-    dest: "{ {k8s_conf_dir }}/{{ item }}"
+    dest: "{{ k8s_conf_dir }}/{{ item }}"
     mode: 0640
     owner: root
     group: root


### PR DESCRIPTION
A space got swapped on line 18; this un-swaps it so things work.